### PR TITLE
Check multiple dropboxes for successful/failed batches

### DIFF
--- a/env-example.txt
+++ b/env-example.txt
@@ -21,4 +21,4 @@ DTS_ENDPOINT=https://ltsds-cloud-dev-1.lib.harvard.edu:10581
 
 # Dropboxes
 BASE_DROPBOX_PATH=/home/appuser/dropbox
-DROPBOX_DIRS=/dvndev, /epadddev_secure
+DROPBOX_DIRS=dvndev, epadddev_secure

--- a/env-example.txt
+++ b/env-example.txt
@@ -19,6 +19,6 @@ DAY_OF_WEEK=*
 # DTS
 DTS_ENDPOINT=https://ltsds-cloud-dev-1.lib.harvard.edu:10581
 
-# Dropbox
-DROPBOX_PATH=/home/appuser/dropbox
-DROPBOX_NAME=/dvndev
+# Dropboxes
+BASE_DROPBOX_PATH=/home/appuser/dropbox
+DROPBOX_DIRS=/dvndev, /epadddev_secure

--- a/monitor_dropbox.py
+++ b/monitor_dropbox.py
@@ -17,21 +17,23 @@ logging.basicConfig(filename=logname_template.format(datetime.today().strftime("
                     level=logging.DEBUG)
 
 dts_endpoint = os.environ.get('DTS_ENDPOINT')
-dropbox_root_dir = os.environ.get('DROPBOX_PATH')
-dropbox_name = os.environ.get('DROPBOX_NAME')
+dropbox_root_dir = os.environ.get('BASE_DROPBOX_PATH')
+dropbox_dirs = os.environ.get('DROPBOX_DIRS')
+dropbox_list = dropbox_dirs.split(",")
 
 logging.debug("Executing monitor_dropbox.py")
 
 
 def collect_loadreports():
     loadreport_files = []
-    loadreport_dir = dropbox_root_dir + "/lts_load_reports" + dropbox_name + "/incoming"
-    logging.debug("Checking for load reports in dropbox loc: " + loadreport_dir)
+    for dropbox in dropbox_list:
+        loadreport_dir = dropbox_root_dir + "/lts_load_reports" + dropbox + "/incoming"
+        logging.debug("Checking for load reports in dropbox loc: " + loadreport_dir)
 
-    for root, dirs, files in os.walk(loadreport_dir):
-        for name in files:
-            if re.match("LOADREPORT", name):
-                loadreport_files.append(name)
+        for root, dirs, files in os.walk(loadreport_dir):
+            for name in files:
+                if re.match("LOADREPORT", name):
+                    loadreport_files.append(name)
 
     return loadreport_files
 
@@ -48,14 +50,15 @@ def notify_dts_loadreports(filename):
 
 def collect_failed_batch():
     failed_batch = []
-    failed_batch_dir = dropbox_root_dir + dropbox_name + "/incoming"
-    logging.debug("Checking failed batches in loc: " + failed_batch_dir)
+    for dropbox in dropbox_list:
+        failed_batch_dir = dropbox_root_dir + dropbox + "/incoming"
+        logging.debug("Checking failed batches in loc: " + failed_batch_dir)
 
-    for root, dirs, files in os.walk(failed_batch_dir):
-        for name in files:
-            if re.match("batch.xml.failed", name):
-                split_path = root.split("/")
-                failed_batch.append(split_path.pop())
+        for root, dirs, files in os.walk(failed_batch_dir):
+            for name in files:
+                if re.match("batch.xml.failed", name):
+                    split_path = root.split("/")
+                    failed_batch.append(split_path.pop())
 
     return failed_batch
 

--- a/monitor_dropbox.py
+++ b/monitor_dropbox.py
@@ -27,7 +27,7 @@ logging.debug("Executing monitor_dropbox.py")
 def collect_loadreports():
     loadreport_files = []
     for dropbox in dropbox_list:
-        loadreport_dir = dropbox_root_dir + "/lts_load_reports" + dropbox + "/incoming"
+        loadreport_dir = os.path.join(dropbox_root_dir, "lts_load_reports", dropbox, "incoming")
         logging.debug("Checking for load reports in dropbox loc: " + loadreport_dir)
 
         for root, dirs, files in os.walk(loadreport_dir):
@@ -51,7 +51,7 @@ def notify_dts_loadreports(filename):
 def collect_failed_batch():
     failed_batch = []
     for dropbox in dropbox_list:
-        failed_batch_dir = dropbox_root_dir + dropbox + "/incoming"
+        failed_batch_dir = os.path.join(dropbox_root_dir, dropbox, "incoming")
         logging.debug("Checking failed batches in loc: " + failed_batch_dir)
 
         for root, dirs, files in os.walk(failed_batch_dir):

--- a/monitor_dropbox.py
+++ b/monitor_dropbox.py
@@ -19,7 +19,7 @@ logging.basicConfig(filename=logname_template.format(datetime.today().strftime("
 dts_endpoint = os.environ.get('DTS_ENDPOINT')
 dropbox_root_dir = os.environ.get('BASE_DROPBOX_PATH')
 dropbox_dirs = os.environ.get('DROPBOX_DIRS')
-dropbox_list = dropbox_dirs.split(",")
+dropbox_list = dropbox_dirs.replace(" ", "").split(",")
 
 logging.debug("Executing monitor_dropbox.py")
 

--- a/monitor_dropbox.py
+++ b/monitor_dropbox.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import os.path
 import re
 import sys
 import traceback

--- a/tests/data/drs2dev/drsfs/dropbox/lts_load_reports/epadddev_secure/incoming/LOADREPORT_test.txt
+++ b/tests/data/drs2dev/drsfs/dropbox/lts_load_reports/epadddev_secure/incoming/LOADREPORT_test.txt
@@ -1,0 +1,1 @@
+This is a test!

--- a/tests/data/drs2dev/drsfs/dropbox/lts_load_reports/epadddev_secure/incoming/LOADREPORT_test2.txt
+++ b/tests/data/drs2dev/drsfs/dropbox/lts_load_reports/epadddev_secure/incoming/LOADREPORT_test2.txt
@@ -1,0 +1,1 @@
+This is a test!

--- a/tests/data/drs2dev/drsfs/dropbox/lts_load_reports/epadddev_secure/incoming/LOADREPORT_test3.txt
+++ b/tests/data/drs2dev/drsfs/dropbox/lts_load_reports/epadddev_secure/incoming/LOADREPORT_test3.txt
@@ -1,0 +1,1 @@
+This is a test!


### PR DESCRIPTION
**Check multiple dropboxes for successful/failed batches**
* * *

**GitHub Issue**: [epadd#92](https://app.zenhub.com/workspaces/epadd-harvard-62c485cd49f954001312ebdd/issues/harvard-lts/epadd/92)

# What does this Pull Request do?
This PR expands the code to include a list of dropboxes to check for LOADREPORT and batch.xml.failed files

# How should this be tested?

1. Deploy to dev (this is already done through the trial branch)
2. Check logs at `/logs/hdc3a/cron`
3. Confirm the following lines are in the logs, ensuring both dropboxes are checked for successful and failed batches:
`Checking for load reports in dropbox loc: /home/appuser/dropbox/lts_load_reports/dvndev/incoming`
`Checking for load reports in dropbox loc: /home/appuser/dropbox/lts_load_reports/epadddev_secure/incoming`
`Checking failed batches in loc: /home/appuser/dropbox/dvndev/incoming`
`Checking failed batches in loc: /home/appuser/dropbox/epadddev_secure/incoming`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n/a
- integration tests? n/a

# Interested parties
@ives1227 
