### PR TITLE
Added 3s sleep between each load report call

### DIFF
--- a/monitor_dropbox.py
+++ b/monitor_dropbox.py
@@ -7,7 +7,7 @@ import re
 import sys
 import traceback
 from datetime import datetime
-
+import time
 from requests import exceptions, get, HTTPError
 
 DATEFORMAT = '%Y-%m-%d %H:%M:%S'
@@ -91,6 +91,7 @@ def main():
         for loadreport in load_report_list:
             if testing == "False":
                 notify_dts_loadreports(loadreport, dropbox)
+                time.sleep(3)
 
     # Collect failed ingests
     failed_batches = collect_failed_batch()


### PR DESCRIPTION
**Slows the calls for Load Report processing down to be handled by the ETD consumer**
* * *

**GitHub Issue**: https://at-harvard.atlassian.net/browse/ETD-363

# How should this be tested?

Deployed and tested in dev

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no

# Interested parties
Tag (@ mention) interested parties
